### PR TITLE
feat: add support for breaking changes in Hugo v0.120.0 - fix display of addresses

### DIFF
--- a/modules/blox-bootstrap/layouts/partials/functions/get_address.html
+++ b/modules/blox-bootstrap/layouts/partials/functions/get_address.html
@@ -13,11 +13,11 @@
 {{ $address_display := slice }}
 
 {{ range $k, $v := $format.order }}
-  {{ if eq $v "street" | and $address.street }}{{$address_display = $address_display | append $address.street | append (index $format.delimiters $k | default "") }}{{end}}
-  {{ if eq $v "city" | and $address.city }}{{$address_display = $address_display | append $address.city | append (index $format.delimiters $k | default "") }}{{end}}
-  {{ if eq $v "region" | and $address.region }}{{$address_display = $address_display | append $address.region | append (index $format.delimiters $k | default "") }}{{end}}
-  {{ if eq $v "postcode" | and $address.postcode }}{{$address_display = $address_display | append $address.postcode | append (index $format.delimiters $k | default "") }}{{end}}
-  {{ if eq $v "country" | and $address.country }}{{$address_display = $address_display | append $address.country | append (index $format.delimiters $k | default "") }}{{end}}
+  {{ if eq $v "street" | and $address.street }}{{$address_display = $address_display | append (transform.HTMLEscape $address.street) | append (index $format.delimiters $k | default "") }}{{end}}
+  {{ if eq $v "city" | and $address.city }}{{$address_display = $address_display | append (transform.HTMLEscape $address.city) | append (index $format.delimiters $k | default "") }}{{end}}
+  {{ if eq $v "region" | and $address.region }}{{$address_display = $address_display | append (transform.HTMLEscape $address.region) | append (index $format.delimiters $k | default "") }}{{end}}
+  {{ if eq $v "postcode" | and $address.postcode }}{{$address_display = $address_display | append (transform.HTMLEscape $address.postcode) | append (index $format.delimiters $k | default "") }}{{end}}
+  {{ if eq $v "country" | and $address.country }}{{$address_display = $address_display | append (transform.HTMLEscape $address.country) | append (index $format.delimiters $k | default "") }}{{end}}
 {{end}}
 
-{{ return (delimit $address_display "") }}
+{{ return safeHTML (delimit $address_display "") }}


### PR DESCRIPTION
### Purpose

Fix the display of addresses with delimiters.

### Screenshots

#### Before

![before](https://github.com/HugoBlox/hugo-blox-builder/assets/974662/ac08067c-28b2-415e-bc80-88be1b76166f)

#### After

![after](https://github.com/HugoBlox/hugo-blox-builder/assets/974662/bd7996b5-487b-4c7c-9f2c-3cb901532021)

