### PR TITLE
Added support for comentario.

### DIFF
--- a/modules/blox-bootstrap/layouts/partials/comments/comentario.html
+++ b/modules/blox-bootstrap/layouts/partials/comments/comentario.html
@@ -1,0 +1,3 @@
+<comentario-comments></comentario-comments>
+{{ $url := (printf "%s/comentario.js" (site.Params.features.comment.comentario.url | default "https://edge.comentario.app")) }}
+<script src="{{$url}}" defer></script>

--- a/modules/blox-tailwind/layouts/partials/comments/comentario.html
+++ b/modules/blox-tailwind/layouts/partials/comments/comentario.html
@@ -1,0 +1,3 @@
+<comentario-comments></comentario-comments>
+{{ $url := (printf "%s/comentario.js" (site.Params.features.comment.comentario.url | default "https://edge.comentario.app")) }}
+<script src="{{$url}}" defer></script>

--- a/starters/academic-cv/config/_default/params.yaml
+++ b/starters/academic-cv/config/_default/params.yaml
@@ -81,6 +81,8 @@ features:
     disqus:
       shortname: ''
       show_count: true
+    comentario:
+      url: ''
     commento:
       url: ''
     giscus:

--- a/starters/course/config/_default/params.yaml
+++ b/starters/course/config/_default/params.yaml
@@ -77,6 +77,8 @@ features:
     disqus:
       shortname: ''
       show_count: true
+    comentario:
+      url: ''
     commento:
       url: ''
     giscus:

--- a/starters/documentation/config/_default/params.yaml
+++ b/starters/documentation/config/_default/params.yaml
@@ -79,6 +79,8 @@ features:
     disqus:
       shortname: ''
       show_count: true
+    comentario:
+      url: ''
     commento:
       url: ''
     giscus:

--- a/starters/portfolio/config/_default/params.yaml
+++ b/starters/portfolio/config/_default/params.yaml
@@ -80,6 +80,8 @@ features:
     disqus:
       shortname: ''
       show_count: true
+    comentario:
+      url: ''
     commento:
       url: ''
     giscus:

--- a/starters/research-group/config/_default/params.yaml
+++ b/starters/research-group/config/_default/params.yaml
@@ -83,6 +83,8 @@ features:
     disqus:
       shortname: ''
       show_count: true
+    comentario:
+      url: ''
     commento:
       url: ''
     giscus:

--- a/starters/second-brain/config/_default/params.yaml
+++ b/starters/second-brain/config/_default/params.yaml
@@ -75,6 +75,8 @@ features:
     disqus:
       shortname: ''
       show_count: true
+    comentario:
+      url: ''
     commento:
       url: ''
     giscus:


### PR DESCRIPTION
### Purpose

During the last few years, I've been using Commento to provide comments on my blog. Unfortunately, it has now become abandonware, with [the last commit dating back to 2021](https://gitlab.com/commento/commento) and [merge requests remaining unanswered](https://gitlab.com/commento/commento/-/merge_requests). 

Luckily, a new maintainer has emerged and created a new fork, [Comentario](https://gitlab.com/comentario/comentario). After a rewrite, they have chosen to use [a web component rather than a div](https://docs.comentario.app/en/installation/migration/commento/). 

I would like to make use of this fork and I've therefore gone through all the layout partials and `params.yaml` files to add Comentario support. This should make it possible to replace Commento.
