### PR TITLE
feat: support facet filters for docsearch

### DIFF
--- a/modules/blox-bootstrap/layouts/partials/site_js.html
+++ b/modules/blox-bootstrap/layouts/partials/site_js.html
@@ -91,6 +91,9 @@
   {{ $algoliaConfig = dict "appId" (site.Params.features.search.algolia.app_id | default "") "apiKey" (site.Params.features.search.algolia.api_key | default "") "indexName" (site.Params.features.search.algolia.index_name | default "") "analytics" (site.Params.features.search.algolia.analytics | default false) "personalization" (site.Params.features.search.algolia.personalization | default false) }}
 {{ else if eq $search_provider "docsearch" }}
   {{ $docsearch_config := dict "appId" (site.Params.features.search.docsearch.app_id | default "") "apiKey" (site.Params.features.search.docsearch.api_key | default "") "indexName" (site.Params.features.search.docsearch.index_name | default "") "container" (site.Params.features.search.docsearch.container | default "#docsearch") }}
+  {{ if (site.Params.features.search.docsearch.search_parameters.facetFilters) }}
+  {{ $docsearch_config = merge $docsearch_config (dict  (slice "searchParameters" "facetFilters")  (site.Params.features.search.docsearch.search_parameters.facetFilters ))}}
+  {{ end }}
   <script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
   {{ printf "<script>docsearch(%s);</script>" ($docsearch_config | jsonify) | safeHTML }}
 {{ end }}


### PR DESCRIPTION
### Purpose

Extend the configuration parameters of docsearch to support facets.

Docsearch has something called 'facets' where you can restrict the results based on record attributes in the indexed results. E.g. if the crawler extracts version information from your pages you can restrict search results to latest. See

https://docsearch.algolia.com/docs/docsearch-v3/#filtering-your-search

Fixes #3022

### Documentation

https://bootstrap.hugoblox.com/hugo-tutorials/search/#docsearch

```yaml
features:
  search:
    provider: docsearch
    docsearch:
      app_id: 'PASTE ID'
      api_key: 'PASTE KEY'
      index_name: 'PASTE INDEX NAME'
      # Optional search parameters, currently only facetFilters supported.
      search_parameters:
        facetFilters: 
          - '<ATTRIBUTE-NAME>:<VALUE>'
          - '<ATTRIBUTE-NAME>:<VALUE>'
```
If you like to limit the results of your search to specific topics, you can define `facetFilters` based on the attributes indexed by the algolia crawler. This is useful to limit search results for example to specific language or a specific version (e.g. `version:latest`). Details on the required docsearch configuration can be found [here](https://www.algolia.com/doc/guides/managing-results/refine-results/faceting/).

Adding [DocSearch meta tags](https://docsearch.algolia.com/docs/required-configuration#introduce-global-information-as-meta-tags) can be added to your site by creating a customized [head-end hook](https://bootstrap.hugoblox.com/hugo-tutorials/extending-wowchemy/#hooks) based on page frontmatter. 

```html
<meta name="docsearch:language" content="en">
<meta name="docsearch:date" content="{{ .Date.UTC.Unix | safeHTML }}">
<meta name="docsearch:lastmod" content="{{ .Lastmod.UTC.Unix | safeHTML }}">
<meta name="docsearch:version" content=".Params.version">
```
