### PR TITLE
research-group starter: only render author pages for configured user accounts

### DIFF
--- a/starters/research-group/content/authors/_index.md
+++ b/starters/research-group/content/authors/_index.md
@@ -1,0 +1,11 @@
+---
+cms_exclude: true
+
+# To publish all author profile pages, remove all of the `_build` and `cascade` settings below.
+_build:
+  render: never
+cascade:
+  _build:
+    render: never
+    list: always
+---

--- a/starters/research-group/content/authors/admin/_index.md
+++ b/starters/research-group/content/authors/admin/_index.md
@@ -1,4 +1,7 @@
 ---
+_build:
+  render: always
+
 # Display name
 title: Nelson Bighetti
 

--- a/starters/research-group/content/authors/吳恩達/_index.md
+++ b/starters/research-group/content/authors/吳恩達/_index.md
@@ -1,4 +1,7 @@
 ---
+_build:
+  render: always
+
 # Display name
 title: Alice Wu 吳恩達
 


### PR DESCRIPTION
### Purpose

The research-group starter renders author pages for all authors, including those having no user account in `content/authors`. This behaviour is disabled in other starters such as academic-cv, and I'd argue it's undesirable for a research group in the vast majority of cases as well.

The proposed change disables rendering of all author pages, and specifically enables rendering in the two example user accounts.

### Screenshots

No screenshot, but the stock research-group starter results in http://localhost:1313/author/robert-ford/ being rendered, although the example Robert Ford has no user account.
