### PR TITLE
Update revealjs to its latest version (5.0.4)

### DIFF
--- a/modules/blox-plugin-reveal/layouts/slides/baseof.html
+++ b/modules/blox-plugin-reveal/layouts/slides/baseof.html
@@ -3,7 +3,7 @@
 <head>
 
   {{/* Asset versions */}}
-  {{ $cdn_url_reveal := "https://cdn.jsdelivr.net/npm/reveal.js@4.6.1" }}
+  {{ $cdn_url_reveal := "https://cdn.jsdelivr.net/npm/reveal.js@5.0.4" }}
   {{ $mermaid_version := "9.1.3" }}
   {{ $mermaid_sri := "sha256-TIYL00Rhw/8WaoUhYTLX9SKIEFdXxg+yMWSLVUbhiLg=" }}
 


### PR DESCRIPTION
Main new feature is [**scroll view**](https://revealjs.com/scroll-view/), which is the new default for mobile view.

I have tested this new version with my own slides and haven't seen any regression/bug.