### PR TITLE
Tiny fix ms-Arab.yaml

### DIFF
--- a/modules/blox-tailwind/i18n/ms-Arab.yaml
+++ b/modules/blox-tailwind/i18n/ms-Arab.yaml
@@ -262,7 +262,7 @@
 # Published with
 
 - id: published_with
-  translation: دتربيتکنن دڠن {hugoblox} — ڤمبوات لامن ويب ڤرچوما {repo_link}برسومبر تربوک{/repolink} دان برکواس
+  translation: دتربيتکنن دڠن {hugoblox} — ڤمبوات لامن ويب ڤرچوما {repo_link}برسومبر تربوک{/repo_link} دان برکواس
 
 # Feedback widget
 


### PR DESCRIPTION
Somehow overlooked the underscore.

This fixed the repo link
![image](https://github.com/HugoBlox/hugo-blox-builder/assets/34799053/cbbe6610-bf75-4a24-b1b8-138860bf8062)

Screenshot from old build
