### PR TITLE
Add first and last name fields to decap_cms_config.yaml

### DIFF
--- a/modules/blox-plugin-decap-cms/data/decap_cms_config.yaml
+++ b/modules/blox-plugin-decap-cms/data/decap_cms_config.yaml
@@ -14,6 +14,8 @@ collections:
     create: true  # Allow users to create new documents in this collection
     fields:  # The fields each document in this collection have
       - {label: "Display name (such as your full name)", name: "title", widget: "string"}
+      - {label: "First name", name: "first_name", widget: "string", required: false}
+      - {label: "Last name", name: "last_name", widget: "string", required: false}
       - {label: "Position or tagline (such as Professor of AI)", name: "role", widget: "string", required: false}
       - label: "Avatar (upload an image named `avatar.jpg/png`)"
         name: "avatar_filename"


### PR DESCRIPTION
### Purpose

Since the front matter fields `first_name` and `last_name` are used for things like SEO and sorting on the people page by default, it would be reasonable IMO to add them to the CMS so that they don't have to be modified manually outside of CMS.

### Screenshots

![grafik](https://github.com/HugoBlox/hugo-blox-builder/assets/136091729/3d82c212-076d-4a49-8bb4-6583db2f9805)

### Documentation

Since the [Decap CMS section](https://docs.hugoblox.com/getting-started/cms/decap/) does not contain any details on all available fields, it looks to me as if it wouldn't need to be updated.

Please do let me know if any changes are needed before merging. Thanks.
