### PR TITLE
Fix translation id of paper conference

### DIFF
--- a/modules/blox-bootstrap/i18n/ar.yaml
+++ b/modules/blox-bootstrap/i18n/ar.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: موقع
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: ورقة مؤتمر
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/bn.yaml
+++ b/modules/blox-bootstrap/i18n/bn.yaml
@@ -174,7 +174,7 @@
 - id: location # Location
   translation: অবস্থান
 
-- id: paper-conference # Conference paper
+- id: pub_paper_conference # Conference paper
   translation: সম্মেলন নিবন্ধ
 
 - id: pub_article_journal # Journal article

--- a/modules/blox-bootstrap/i18n/ca.yaml
+++ b/modules/blox-bootstrap/i18n/ca.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Ubicació
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/cs.yaml
+++ b/modules/blox-bootstrap/i18n/cs.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Místo
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Materiál ke konferenci
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/da.yaml
+++ b/modules/blox-bootstrap/i18n/da.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lokation
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konference artikel
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/de.yaml
+++ b/modules/blox-bootstrap/i18n/de.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Ort
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferenzpapier
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/el.yaml
+++ b/modules/blox-bootstrap/i18n/el.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Τοποθεσία
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/es.yaml
+++ b/modules/blox-bootstrap/i18n/es.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Localización
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Artículo de conferencia
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/et.yaml
+++ b/modules/blox-bootstrap/i18n/et.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Asukoht
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Ettekanne
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/eu.yaml
+++ b/modules/blox-bootstrap/i18n/eu.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Kokalekua
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferentzia-artikulua
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/fa.yaml
+++ b/modules/blox-bootstrap/i18n/fa.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: مکان
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: مقاله کنفرانسی
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/fi.yaml
+++ b/modules/blox-bootstrap/i18n/fi.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Sijainti
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferenssijulkaisu
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/fr.yaml
+++ b/modules/blox-bootstrap/i18n/fr.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lieu
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Article de conférence
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/he.yaml
+++ b/modules/blox-bootstrap/i18n/he.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: מיקום
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: נייר ועידה
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/hu.yaml
+++ b/modules/blox-bootstrap/i18n/hu.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Helyszín
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/id.yaml
+++ b/modules/blox-bootstrap/i18n/id.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lokasi
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Kertas konferensi
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/it.yaml
+++ b/modules/blox-bootstrap/i18n/it.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Luogo
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/ja.yaml
+++ b/modules/blox-bootstrap/i18n/ja.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: 場所
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 学会論文
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/km.yaml
+++ b/modules/blox-bootstrap/i18n/km.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: ទីតាំង
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: សន្និសិទ
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/ko.yaml
+++ b/modules/blox-bootstrap/i18n/ko.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: 장소
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 학술 대회 논문
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/lt.yaml
+++ b/modules/blox-bootstrap/i18n/lt.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lokacija
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferencijos publikacija
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/lv.yaml
+++ b/modules/blox-bootstrap/i18n/lv.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Vieta
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Uzstāšanās konferencē
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/mg.yaml
+++ b/modules/blox-bootstrap/i18n/mg.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Toerana
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Taratasy fihaonambe
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/ms-Arab.yaml
+++ b/modules/blox-bootstrap/i18n/ms-Arab.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: کدودوقن
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: کرتس سيدڠ
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/ms.yaml
+++ b/modules/blox-bootstrap/i18n/ms.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Kedudukan
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Kertas sidang
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/nb.yaml
+++ b/modules/blox-bootstrap/i18n/nb.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Sted
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferanseartikkel
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/nl.yaml
+++ b/modules/blox-bootstrap/i18n/nl.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Locatie
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conferentiepaper
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/pl.yaml
+++ b/modules/blox-bootstrap/i18n/pl.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Miejsce
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Prezentacja z konferencji
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/pt.yaml
+++ b/modules/blox-bootstrap/i18n/pt.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Local
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Artigo de conferência
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/ro.yaml
+++ b/modules/blox-bootstrap/i18n/ro.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Localizare
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/ru.yaml
+++ b/modules/blox-bootstrap/i18n/ru.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Место
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Статья для конференции
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/so.yaml
+++ b/modules/blox-bootstrap/i18n/so.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Meel
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Qoraal Shir
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/sv.yaml
+++ b/modules/blox-bootstrap/i18n/sv.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Plats
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferensbidrag
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/tr.yaml
+++ b/modules/blox-bootstrap/i18n/tr.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Adres
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/uk.yaml
+++ b/modules/blox-bootstrap/i18n/uk.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Місце
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Стаття для конференції
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/zh-Hant.yaml
+++ b/modules/blox-bootstrap/i18n/zh-Hant.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: 位置
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 會議文章
 
 - id: pub_article_journal

--- a/modules/blox-bootstrap/i18n/zh.yaml
+++ b/modules/blox-bootstrap/i18n/zh.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: 位置
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 会议文章
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/ar.yaml
+++ b/modules/blox-tailwind/i18n/ar.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: موقع
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: ورقة مؤتمر
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/bn.yaml
+++ b/modules/blox-tailwind/i18n/bn.yaml
@@ -174,7 +174,7 @@
 - id: location # Location
   translation: অবস্থান
 
-- id: paper-conference # Conference paper
+- id: pub_paper_conference # Conference paper
   translation: সম্মেলন নিবন্ধ
 
 - id: pub_article_journal # Journal article

--- a/modules/blox-tailwind/i18n/ca.yaml
+++ b/modules/blox-tailwind/i18n/ca.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Ubicació
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/cs.yaml
+++ b/modules/blox-tailwind/i18n/cs.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Místo
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Materiál ke konferenci
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/da.yaml
+++ b/modules/blox-tailwind/i18n/da.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lokation
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konference artikel
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/de.yaml
+++ b/modules/blox-tailwind/i18n/de.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Ort
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferenzpapier
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/el.yaml
+++ b/modules/blox-tailwind/i18n/el.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Τοποθεσία
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/es.yaml
+++ b/modules/blox-tailwind/i18n/es.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Localización
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Artículo de conferencia
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/et.yaml
+++ b/modules/blox-tailwind/i18n/et.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Asukoht
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Ettekanne
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/eu.yaml
+++ b/modules/blox-tailwind/i18n/eu.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Kokalekua
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferentzia-artikulua
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/fa.yaml
+++ b/modules/blox-tailwind/i18n/fa.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: مکان
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: مقاله کنفرانسی
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/fi.yaml
+++ b/modules/blox-tailwind/i18n/fi.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Sijainti
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferenssijulkaisu
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/fr.yaml
+++ b/modules/blox-tailwind/i18n/fr.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lieu
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Article de conférence
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/he.yaml
+++ b/modules/blox-tailwind/i18n/he.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: מיקום
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: נייר ועידה
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/hu.yaml
+++ b/modules/blox-tailwind/i18n/hu.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Helyszín
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/id.yaml
+++ b/modules/blox-tailwind/i18n/id.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lokasi
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Kertas konferensi
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/it.yaml
+++ b/modules/blox-tailwind/i18n/it.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Luogo
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/ja.yaml
+++ b/modules/blox-tailwind/i18n/ja.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: 場所
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 学会論文
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/km.yaml
+++ b/modules/blox-tailwind/i18n/km.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: ទីតាំង
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: សន្និសិទ
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/ko.yaml
+++ b/modules/blox-tailwind/i18n/ko.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: 장소
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 학술 대회 논문
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/lt.yaml
+++ b/modules/blox-tailwind/i18n/lt.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Lokacija
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferencijos publikacija
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/lv.yaml
+++ b/modules/blox-tailwind/i18n/lv.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Vieta
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Uzstāšanās konferencē
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/mg.yaml
+++ b/modules/blox-tailwind/i18n/mg.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Toerana
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Taratasy fihaonambe
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/ms-Arab.yaml
+++ b/modules/blox-tailwind/i18n/ms-Arab.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: کدودوقن
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: کرتس سيدڠ
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/ms.yaml
+++ b/modules/blox-tailwind/i18n/ms.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Kedudukan
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Kertas sidang
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/nb.yaml
+++ b/modules/blox-tailwind/i18n/nb.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Sted
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferanseartikkel
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/nl.yaml
+++ b/modules/blox-tailwind/i18n/nl.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Locatie
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conferentiepaper
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/pl.yaml
+++ b/modules/blox-tailwind/i18n/pl.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Miejsce
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Prezentacja z konferencji
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/pt.yaml
+++ b/modules/blox-tailwind/i18n/pt.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Local
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Artigo de conferência
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/ro.yaml
+++ b/modules/blox-tailwind/i18n/ro.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Localizare
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/ru.yaml
+++ b/modules/blox-tailwind/i18n/ru.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Место
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Статья для конференции
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/so.yaml
+++ b/modules/blox-tailwind/i18n/so.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Meel
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Qoraal Shir
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/sv.yaml
+++ b/modules/blox-tailwind/i18n/sv.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Plats
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Konferensbidrag
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/tr.yaml
+++ b/modules/blox-tailwind/i18n/tr.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Adres
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Conference paper
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/uk.yaml
+++ b/modules/blox-tailwind/i18n/uk.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: Місце
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: Стаття для конференції
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/zh-Hant.yaml
+++ b/modules/blox-tailwind/i18n/zh-Hant.yaml
@@ -174,7 +174,7 @@
 - id: location
   translation: 位置
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 會議文章
 
 - id: pub_article_journal

--- a/modules/blox-tailwind/i18n/zh.yaml
+++ b/modules/blox-tailwind/i18n/zh.yaml
@@ -180,7 +180,7 @@
 - id: location
   translation: 位置
 
-- id: paper-conference
+- id: pub_paper_conference
   translation: 会议文章
 
 - id: pub_article_journal


### PR DESCRIPTION
### Purpose

Describe the purpose of this change. If there is an existing issue that is resolved by this pull request, please reference it in the form `Fixes #1234` where 1234 is the relevant issue number.

Fix translation id of `paper-conference` publication type.

### Screenshots

If this is a GUI change, try to include screenshots of the change. If not, please delete this section.

Correct the translation of paper conference. Bad behavior before this fix:

<img width="215" alt="image" src="https://github.com/HugoBlox/hugo-blox-builder/assets/6127678/602490b4-a863-4326-aa3c-5a1f5fe3f3fc">

### Documentation

If this is an enhancement, link to the relevant page on the documentation site and describe the necessary changes.

N/A
