### PR TITLE
Fix error in showcase.html

### DIFF
--- a/modules/blox-bootstrap/layouts/partials/views/showcase.html
+++ b/modules/blox-bootstrap/layouts/partials/views/showcase.html
@@ -27,8 +27,6 @@
   {{ if and ($widget.Params.design.flip_alt_rows | default true) (not (modBool $index 2)) }}
     {{ $order = "order-md-2" }}
   {{ end }}
-{{ else if and ($widget.design.flip_alt_rows | default true) (not (modBool $index 2)) }}
-  {{ $order = "order-md-2" }}
 {{ end }}
 
 


### PR DESCRIPTION
Widget.design is not a field. This raises an error when trying to use `showcase` in a widget.

```
layouts/partials/views/showcase.html:30:23": execute of template failed: template: partials/views/showcase.html:30:23: executing "partials/views/showcase.html" at <$widget.design.flip_alt_rows>: can't evaluate field design in type*hugolib.pageState
```

This PR fixed it.