### PR TITLE
Remove fetching of default GA ID via site config

### DIFF
--- a/modules/blox-seo/layouts/partials/analytics/google_analytics.html
+++ b/modules/blox-seo/layouts/partials/analytics/google_analytics.html
@@ -1,4 +1,4 @@
-{{ $ga := site.Params.marketing.analytics.google_analytics | default site.GoogleAnalytics | default "" }}
+{{ $ga := site.Params.marketing.analytics.google_analytics | default "" }}
 
 {{ if hugo.IsProduction | and $ga }}
 


### PR DESCRIPTION
### Purpose

site.GoogleAnalytics is deprecated since Hugo v0.120.0 and would need to be changed to site.Config.Services.GoogleAnalytics.ID, which breaks compatibility with earlier Hugo versions. Thus, omit fetching this configuration variable since it should be set via site.Params.marketing.analytics.google_analytics anyway.
On request of @gcushen via Discord discussion.