### PR TITLE
fix error: Use .Site.Config.Services.GoogleAnalytics.ID instead.

### DIFF
--- a/modules/blox-bootstrap/layouts/partials/components/feedback.html
+++ b/modules/blox-bootstrap/layouts/partials/components/feedback.html
@@ -1,4 +1,4 @@
-{{ $ga := site.Params.marketing.analytics.google_analytics | default site.GoogleAnalytics | default "" }}
+{{ $ga := site.Params.marketing.analytics.google_analytics | default site.Config.Services.GoogleAnalytics.ID | default "" }}
 {{ $show_feedback := .Params.feedback | default true }}
 
 {{ if hugo.IsProduction | and $ga | and $show_feedback }}

--- a/modules/blox-seo/layouts/partials/analytics/google_analytics.html
+++ b/modules/blox-seo/layouts/partials/analytics/google_analytics.html
@@ -1,4 +1,4 @@
-{{ $ga := site.Params.marketing.analytics.google_analytics | default site.GoogleAnalytics | default "" }}
+{{ $ga := site.Params.marketing.analytics.google_analytics | default site.Config.Services.GoogleAnalytics.ID | default "" }}
 
 {{ if hugo.IsProduction | and $ga }}
 

--- a/modules/blox-tailwind/layouts/partials/components/feedback.html
+++ b/modules/blox-tailwind/layouts/partials/components/feedback.html
@@ -1,5 +1,5 @@
 {{/* TODO: port JS & response text from Bootstrap module. Re-integrate with GA plus Fathom/Plausible */}}
-{{/* $ga := site.Params.marketing.analytics.google_analytics | default site.GoogleAnalytics | default "" */}}
+{{/* $ga := site.Params.marketing.analytics.google_analytics | default site.Config.Services.GoogleAnalytics.ID | default "" */}}
 {{ $show_feedback := .Params.feedback | default true }}
 
 {{ if hugo.IsProduction | and $show_feedback }}{{/*  | and $ga */}}


### PR DESCRIPTION
### Purpose

Fix for hugo 0.133.0+ error

ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.134.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.