### PR TITLE
Remove remains of deprecated Site.GoogleAnalytics

### DIFF
--- a/modules/blox-bootstrap/layouts/partials/components/feedback.html
+++ b/modules/blox-bootstrap/layouts/partials/components/feedback.html
@@ -1,4 +1,4 @@
-{{ $ga := site.Params.marketing.analytics.google_analytics | default site.GoogleAnalytics | default "" }}
+{{ $ga := site.Params.marketing.analytics.google_analytics | default "" }}
 {{ $show_feedback := .Params.feedback | default true }}
 
 {{ if hugo.IsProduction | and $ga | and $show_feedback }}

--- a/modules/blox-tailwind/layouts/partials/components/feedback.html
+++ b/modules/blox-tailwind/layouts/partials/components/feedback.html
@@ -1,5 +1,5 @@
 {{/* TODO: port JS & response text from Bootstrap module. Re-integrate with GA plus Fathom/Plausible */}}
-{{/* $ga := site.Params.marketing.analytics.google_analytics | default site.GoogleAnalytics | default "" */}}
+{{/* $ga := site.Params.marketing.analytics.google_analytics | default "" */}}
 {{ $show_feedback := .Params.feedback | default true }}
 
 {{ if hugo.IsProduction | and $show_feedback }}{{/*  | and $ga */}}


### PR DESCRIPTION
### Purpose

Some occurrences of the Site.GoogleAnalytics variable that is deprecated since Hugo 0.133 have not been removed in #3137, as mentioned by @rodrigoalcarazdelaosa in that same PR.
