### PR TITLE
fix: typo in french translation

### DIFF
--- a/modules/blox-bootstrap/i18n/fr.yaml
+++ b/modules/blox-bootstrap/i18n/fr.yaml
@@ -262,4 +262,4 @@
 # Published with
 
 - id: published_with
-  translation: Publié avec {hugoblox} — le générateur {repo_link}libre{/repo_link} de site web gratuit permetant aux créateurs de s'épanouir.
+  translation: Publié avec {hugoblox} — le générateur {repo_link}libre{/repo_link} de site web gratuit permettant aux créateurs de s'épanouir.

--- a/modules/blox-tailwind/i18n/fr.yaml
+++ b/modules/blox-tailwind/i18n/fr.yaml
@@ -262,4 +262,4 @@
 # Published with
 
 - id: published_with
-  translation: Publié avec {hugoblox} — le générateur {repo_link}libre{/repo_link} de site web gratuit permetant aux créateurs de s'épanouir.
+  translation: Publié avec {hugoblox} — le générateur {repo_link}libre{/repo_link} de site web gratuit permettant aux créateurs de s'épanouir.


### PR DESCRIPTION
### Purpose

There's a typo in the french translation of `published_with`, which appears at the bottom of each page:

<img width="770" alt="image" src="https://github.com/user-attachments/assets/c5845aee-2159-462e-9adf-eead223e3b02">

The french word is `permettant` and not `permetant`.

This PR fixes this typo :)