### PR TITLE
Blue note callout

### DIFF
--- a/modules/blox-tailwind/layouts/shortcodes/callout.html
+++ b/modules/blox-tailwind/layouts/shortcodes/callout.html
@@ -9,8 +9,8 @@
         Otherwise, you can add your own icon to assets/media/icons/ and reference its name when calling the shortcode.
 */}}
 {{ $icon := "information-circle" }}
-{{ $class := "bg-primary-100 dark:bg-primary-900" }}
-{{ $class_text := "text-primary-600 dark:text-primary-300" }}
+{{ $class := "bg-blue-100 dark:bg-blue-900" }}
+{{ $class_text := "text-blue-600 dark:text-blue-300" }}
 {{ with (.Get 0) }}
   {{ if eq . "note" }}
     {{ $icon = "information-circle" }}


### PR DESCRIPTION
### Purpose

Markdown "note" callout should have the standard blue color and not the primary color of the theme as it can be confusing if the primary color is red for example, the "note" callout is mistaken as an "error" callout.

### Screenshots
Before the change:
![image](https://github.com/user-attachments/assets/66089024-7df4-4ae2-94de-60ba22e79332)

After the change:
![image](https://github.com/user-attachments/assets/52a4aa8f-6b71-49cb-b5d4-75737cbc58be)
