### PR TITLE
Fingerprint dist/wc.min.css to prevent cache issues

### DIFF
--- a/modules/blox-tailwind/layouts/partials/site_head.html
+++ b/modules/blox-tailwind/layouts/partials/site_head.html
@@ -57,7 +57,7 @@
 
   {{/* Style */}}
   {{ if ne (os.Getenv "HUGO_BLOX_POSTCSS") "true" }}
-    {{ $styles := resources.Get "dist/wc.min.css" }}
+    {{ $styles := resources.Get "dist/wc.min.css" | fingerprint "sha256" }}
     <link href="{{ $styles.RelPermalink }}" rel="stylesheet" />
   {{ else }}
     {{ $options := dict "inlineImports" true }}


### PR DESCRIPTION
### Purpose

We are using Cloudflare Pages to host a website built with Hugo Blox. When updating the CSS, e.g. after adding new Tailwind classes, Cloudflare's cache keeps serving the old version, which breaks the website's layout. This problem can be mitigated by fingerprinting `dist/wc.min.css`.

### Documentation

N/A
