### PR TITLE
Add sort_by support to people widget

### DIFF
--- a/modules/blox-bootstrap/layouts/partials/blocks/v1/people.html
+++ b/modules/blox-bootstrap/layouts/partials/blocks/v1/people.html
@@ -27,6 +27,13 @@
   {{ range $block.Params.content.user_groups }}
   {{ $query := where (where site.Pages "Section" "authors") ".Params.user_groups" "intersect" (slice .) }}
 
+  {{/* Sort */}}
+  {{ $sort_by := $block.Params.content.sort_by | default "Params.last_name" }}
+  {{ $sort_by = partial "blox-core/functions/get_sort_by_parameter" $sort_by }}
+  {{ $sort_ascending := $block.Params.content.sort_ascending | default true }}
+  {{ $sort_order := cond $sort_ascending "asc" "desc" }}
+  {{ $query = sort $query $sort_by $sort_order }}
+
   {{if $query | and (gt (len $block.Params.content.user_groups) 1) }}
   <div class="col-md-12">
     <h2 class="mb-4">{{ . | markdownify }}</h2>

--- a/starters-bootstrap/course/content/home/people.md
+++ b/starters-bootstrap/course/content/home/people.md
@@ -17,6 +17,8 @@ content:
   #   Edit `user_groups` in each user's profile to add them to one or more of these groups.
   user_groups:
     - Teachers
+  sort_by: Params.last_name
+  sort_ascending: true
 design:
   show_interests: false
   show_role: true


### PR DESCRIPTION
### Purpose

If we make use `widget: people` in `home/xxx.md` we cannot sort people. This PR fixes this.

### Documentation

I updated the starters-bootstrap to indicate this change.