### PR TITLE
[FIX] erroneous shadow behind cards in dark theme after tailwind upgrade

### DIFF
--- a/modules/blox-tailwind/assets/css/components/cards.css
+++ b/modules/blox-tailwind/assets/css/components/cards.css
@@ -8,7 +8,7 @@
 }
 
 .hb-card {
-  @apply flex flex-col justify-start overflow-hidden rounded-lg border border-gray-200 text-current no-underline dark:shadow-none hover:shadow-gray-100 dark:hover:shadow-none shadow-gray-100 active:shadow-sm active:shadow-gray-200 transition-all duration-200;
+  @apply flex flex-col justify-start overflow-hidden rounded-lg border border-gray-200 text-current no-underline dark:shadow-transparent hover:shadow-gray-100 dark:hover:shadow-transparent shadow-gray-100 active:shadow-sm active:shadow-gray-200 transition-all duration-200;
   @apply hover:border-gray-300 bg-transparent shadow-sm hover:bg-slate-50 hover:shadow-md;
   border-color: rgb(var(--color-neutral-700));
 }


### PR DESCRIPTION
### Purpose

After the upgrade to Tailwind v4, the `cards` have obtained an ugly white shadow in the dark theme. This is due to a change in the behaviour of `shadow-none` which (erroneously?) sets the shadow to white. I've corrected this by setting the shadow to `shadow-transparent` for the dark mode.

### Screenshots
Tailwind v3 behavior:
<img width="730" height="256" alt="Screenshot 2025-08-30 at 13 19 16" src="https://github.com/user-attachments/assets/c352c29f-98c3-4509-9837-cc23b76ae509" />

Current tailwind v4 behavior:
<img width="728" height="262" alt="Screenshot 2025-08-30 at 13 19 45" src="https://github.com/user-attachments/assets/87193b82-9181-4a25-8ea1-f3a8b73c7400" />

Patched tailwind v4:
<img width="726" height="250" alt="Screenshot 2025-08-30 at 13 19 59" src="https://github.com/user-attachments/assets/88bc80b9-e295-487a-bea7-b730a2a257b8" />
