### PR TITLE
fix: workaround for md5 hash starting with zero

### DIFF
--- a/modules/blox-tailwind/layouts/_partials/site_footer.html
+++ b/modules/blox-tailwind/layouts/_partials/site_footer.html
@@ -36,8 +36,8 @@
     {{- $h := md5 $seed -}}
     {{- $digits := replaceRE "[^0-9]" "" $h -}}
     {{- if lt (len $digits) 6 }}{{- $digits = printf "%s123456" $digits -}}{{- end -}}
-    {{- $n := int (substr $digits 0 6) -}}
-  
+    {{- $n := int (strings.TrimPrefix (substr $digits 0 6) "0") -}}
+
     {{- $brandText := index $brandOptions (mod $n (len $brandOptions)) -}}
     {{- $ctaText   := cond (ne $tid "")
           (index $ctaWhenTemplate (mod $n (len $ctaWhenTemplate)))


### PR DESCRIPTION
### Purpose

When generating md5 hashes, if the hash starts
with a zero, it can cause casting issue from
string to integer as the following:

```
ERROR render of "/home/aki/src/chezo.uno/content/_index.md" failed: "/home/aki/.cache/hugo_cache/modules/filecache/modules/pkg/mod/github.com/!hugo!blox/hugo-blox-builder/modules/blox-tailwind@v0.6.0/layouts/baseof.html:28:9": execute of template failed: template: landing/list.html:28:9: executing "landing/list.html" at <partial "site_footer" .>: error calling partial: "/home/aki/.cache/hugo_cache/modules/filecache/modules/pkg/mod/github.com/!hugo!blox/hugo-blox-builder/modules/blox-tailwind@v0.6.0/layouts/_partials/site_footer.html:39:14": execute of template failed: template: _partials/site_footer.html:39:14: executing "_partials/site_footer.html" at <int (substr $digits 0 6)>: error calling int: unable to cast "095892" of type string to int: strconv.ParseInt: parsing "095892": invalid syntax
```

This commit adds a workaround to trim leading
zeros.


### Documentation

NA