### PR TITLE
Fix progress bar display in resume-languages block

### DIFF
--- a/modules/blox-tailwind/blox/resume-languages/block.html
+++ b/modules/blox-tailwind/blox/resume-languages/block.html
@@ -31,7 +31,7 @@
                   class="text-gray-200 dark:text-gray-700" />
           <circle cx="145" cy="145" r="120" stroke="currentColor" stroke-width="30" fill="transparent"
                   class="text-primary-600 dark:text-primary-300"
-                  style="stroke-dasharray: calc(2 * 22 / 7 * 120); stroke-dashoffset: calc(((2 * 22 / 7 * 120) * {{.percent}}/100) - (2 * 22 / 7 * 120))" />
+                  style=stroke-dasharray: calc(2 * 22 / 7 * 120); stroke-dashoffset: calc((2 * 22 / 7 * 120) - ((2 * 22 / 7 * 120) * {{.percent}}/100))" />
         </svg>
         <span class="absolute text-3xl">{{.percent}}%</span>
       </div>


### PR DESCRIPTION
### Purpose

Fix progress bar display in resume-languages block by correcting stroke-dashoffset calculation to show accurate progress. Previously, progress bars displayed the gap segment (remaining progress) starting from the first quadrant, whereas for 80% progress, it should appear in the 4th quadrant, causing the visual representation to appear inverted.

### Screenshots

**Before:**
<img width="157" height="184" alt="image" src="https://github.com/user-attachments/assets/c8be2c1c-9bfa-469e-8359-865ae6f2276d" />

*Progress bars displayed the gap segment (remaining progress) starting from the first quadrant, whereas for 80% progress it should 
  appear in the 4th quadrant*


**After:**
<img width="175" height="189" alt="image" src="https://github.com/user-attachments/assets/2f494dce-8e6d-4140-bbe3-1d0e77433e84" />
*Progress bars now correctly display 80% proficiency as 80% filled*


### Documentation

It is a bugfix; no documentation change is needed.
