### PR TITLE
Fix hook lookup to search both '_partials' and 'partials' directories

### DIFF
--- a/modules/blox-tailwind/layouts/_partials/functions/get_hook.html
+++ b/modules/blox-tailwind/layouts/_partials/functions/get_hook.html
@@ -5,15 +5,21 @@
 {{ $loaded := false }}
 {{ $partial_dir := printf "hooks/%s/" .hook }}
 {{ $context := .context }}
-{{ $hook_dir_path := path.Join "layouts/_partials" $partial_dir }}
-{{ if fileExists $hook_dir_path }}
-  {{ range os.ReadDir $hook_dir_path }}
-    {{ if not .IsDir }}
-      {{ $partial_path := path.Join $partial_dir .Name }}
-      {{ partial $partial_path $context }}
-      {{ $loaded = true }}
+
+{{/* Check both _partials and partials directories for hooks */}}
+{{ $hook_dirs := slice "layouts/_partials" "layouts/partials" }}
+{{ range $hook_dirs }}
+  {{ $hook_dir_path := path.Join . $partial_dir }}
+  {{ if fileExists $hook_dir_path }}
+    {{ range os.ReadDir $hook_dir_path }}
+      {{ if not .IsDir }}
+        {{ $partial_path := path.Join $partial_dir .Name }}
+        {{ partial $partial_path $context }}
+        {{ $loaded = true }}
+      {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}
+
 {{/* The return statement below is for debug purposes only and prevents the above partial(s) being included in the page */}}
 {{/* return $loaded */}}


### PR DESCRIPTION
### Purpose

Ensure hooks are correctly resolved by searching both _partials and partials directories.
This fixes cases where valid hooks were being ignored due to directory placement.

### TESTING

Test hooks are working with:

`curl -s http://localhost:8081/ | sed -n '/<head>/,/<\/head>/p' | grep "buttons.github.io" || echo "GitHub buttons script not in head"
`
**Before**

```
curl -s http://localhost:8081/ | sed -n '/<head>/,/<\/head>/p' | grep "buttons.github.io" || echo "GitHub buttons script not in head" 
GitHub buttons script not in head

```
**After**
```
curl -s http://localhost:8081/ | sed -n '/<head>/,/<\/head>/p' | grep "buttons.github.io" || echo "GitHub buttons script not in head"
        <script async defer src="https://buttons.github.io/buttons.js"></script>
```

### Documentation
No documentation changes required, as this is an internal behavior fix.
