### PR TITLE
Fix resume-skills block aligns columns to the top instead of the center.

### DIFF
--- a/modules/blox-tailwind/blox/resume-skills/block.html
+++ b/modules/blox-tailwind/blox/resume-skills/block.html
@@ -24,7 +24,7 @@
   {{ with $block.content.text }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
 </div>
 
-<div class="flex flex-col lg:flex-row items-center max-w-prose mx-auto gap-3 px-6 md:px-0">
+<div class="flex flex-col lg:flex-row items-start max-w-prose mx-auto gap-3 px-6 md:px-0">
 
   {{ range $skills }}
   {{ $color := .color | default "" }}


### PR DESCRIPTION
### Purpose

Fix the vertical alignment issue in the resume skills block, where shorter content sections were centering vertically instead of aligning to the top. 

### Testing
Add a long enough description to each item under skills 

```
skills:
  - name: Technical Skills
    items:
      - name: Python & PyTorch
        description: 'Some description text to consume space demonstrating the column start position unevenness'
        percent: 90
        icon: python
      - name: R
        description: 'Some description text to consume space demonstrating the column start position unevenness'
        percent: 80
        icon: r-project
      - name: SQL
        description: 'Some description text to consume space demonstrating the column start position unevenness'
        percent: 70
        percent: 95
        icon: code-bracket
      - name: Machine Learning
        description: ''
        percent: 100
        icon: chart-bar
      - name: Cloud Computing (AWS/GCP)
        description: ''
        percent: 85
        icon: cloud
  - name: Hobbies
    color: '#eeac02'
    color_border: '#f0bf23'
    items:
      - name: Hiking in the Rockies
        description: ''
        percent: 80
        icon: person-simple-walk
      - name: Building Custom PCs
        description: ''
        percent: 90
        icon: cpu-chip
      - name: Sci-Fi Reading
        description: ''
        percent: 70
        icon: book-open

```

### Screenshots

**Before**
<img width="735" height="551" alt="image" src="https://github.com/user-attachments/assets/3494a9cf-697f-414e-b696-d3a1363f9016" />


**After**
<img width="731" height="553" alt="image" src="https://github.com/user-attachments/assets/4799c14a-1f62-4696-9909-e3c286f8db4f" />


### Documenttaion
No documentation changes required, as this is an internal behavior fix.