### PR TITLE
Dynamic columns in resume-skills block

### DIFF
--- a/modules/blox-tailwind/blox/resume-languages/block.html
+++ b/modules/blox-tailwind/blox/resume-languages/block.html
@@ -31,7 +31,7 @@
                   class="text-gray-200 dark:text-gray-700" />
           <circle cx="145" cy="145" r="120" stroke="currentColor" stroke-width="30" fill="transparent"
                   class="text-primary-600 dark:text-primary-300"
-                  style=stroke-dasharray: calc(2 * 22 / 7 * 120); stroke-dashoffset: calc((2 * 22 / 7 * 120) - ((2 * 22 / 7 * 120) * {{.percent}}/100))" />
+                  style="stroke-dasharray: calc(2 * 22 / 7 * 120); stroke-dashoffset: calc((2 * 22 / 7 * 120) - ((2 * 22 / 7 * 120) * {{.percent}}/100))" />
         </svg>
         <span class="absolute text-3xl">{{.percent}}%</span>
       </div>

--- a/modules/blox-tailwind/blox/resume-skills/block.html
+++ b/modules/blox-tailwind/blox/resume-skills/block.html
@@ -24,12 +24,13 @@
   {{ with $block.content.text }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
 </div>
 
-<div class="flex flex-col lg:flex-row items-start max-w-prose mx-auto gap-3 px-6 md:px-0">
+{{ $columns := $block.design.columns | default 2 }}
+<div class="grid grid-cols-1 {{ if ge $columns 2 }}md:grid-cols-2{{ end }} {{ if ge $columns 3 }}lg:grid-cols-3{{ end }} {{ if ge $columns 4 }}xl:grid-cols-4{{ end }} {{ if ge $columns 5 }}2xl:grid-cols-5{{ end }} items-start max-w-prose mx-auto gap-3 px-6 md:px-0">
 
   {{ range $skills }}
   {{ $color := .color | default "" }}
   {{ $color_border := .color_border | default "" }}
-  <div class="w-full lg:w-1/2">
+  <div class="w-full">
     <div class="mb-5 text-xl font-bold text-gray-900 dark:text-white">
       {{ .name | markdownify | emojify }}
       {{ with .description }}<p>{{ . | markdownify | emojify }}</p>{{ end }}


### PR DESCRIPTION
**NOTE:**  This PR depends on changes from https://github.com/HugoBlox/hugo-blox-builder/pull/3259

### Purpose

Add dynamic columns configuration to the resume-skills block with responsive breakpoints. 

Uses standard design.columns parameter (default 2) that creates a progressive responsive grid layout: 1→2→3→4→5 columns across breakpoints (sm→md→lg→xl→2xl). Replaces fixed 2-column flex layout with CSS Grid for better multi-column control and flexibility.

### Testing
Ensure setting three columns in `experience.md`:

```
  - block: skills
    content:
      title: Skills & Hobbies
      username: admin
    design:
      show_skill_percentage: false
      spacing: "3rem 0 0 0"
      columns: 3

```

Add a  third item with several sub-items under skills:

```
skills:
  - name: Technical Skills
    items:
      - name: Python & PyTorch
        description: 'Some description text to consume space demonstrating the column start position unevenness'
        percent: 90
        icon: python
      - name: R
        description: 'Some description text to consume space demonstrating the column start position unevenness'
        percent: 80
        icon: r-project
      - name: SQL
        description: 'Some description text to consume space demonstrating the column start position unevenness'
        percent: 70
        percent: 95
        icon: code-bracket
      - name: Machine Learning
        description: ''
        percent: 100
        icon: chart-bar
      - name: Cloud Computing (AWS/GCP)
        description: ''
        percent: 85
        icon: cloud
  - name: Hobbies
    color: '#eeac02'
    color_border: '#f0bf23'
    items:
      - name: Hiking in the Rockies
        description: ''
        percent: 80
        icon: person-simple-walk
      - name: Building Custom PCs
        description: ''
        percent: 90
        icon: cpu-chip
      - name: Sci-Fi Reading
        description: ''
        percent: 70
        icon: book-open
  - name: 'Something else'
    items:
      - name: 'Sub-item #1'
      - name: 'Sub-item #2'
      - name: 'Sub-item #3'

```

### Screenshots

**Large screen:**

<img width="911" height="518" alt="Screenshot 2025-09-12 at 9 00 45 PM" src="https://github.com/user-attachments/assets/9cf538b8-e7b5-4279-a0da-bde69511de07" />

**Medium:**
<img width="707" height="606" alt="Screenshot 2025-09-12 at 9 00 30 PM" src="https://github.com/user-attachments/assets/af5bf01c-6dfc-4b92-80e6-ecd65bc3bcf0" />

**Small:**
<img width="596" height="649" alt="Screenshot 2025-09-12 at 9 00 13 PM" src="https://github.com/user-attachments/assets/e307c051-5d25-49e6-bb07-817709502776" />


### Documentation

Uses the standard design.columns parameter is available across Hugo Blox blocks. No additional documentation changes required as this follows existing design parameter conventions.